### PR TITLE
Use Python 3.11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
             - name: Install Python
               uses: actions/setup-python@v2
               with:
-                python-version: 3.8
+                python-version: 3.11
             - name: Install dependencies
               run: pip install keyboard pyinstaller
             - name: Build MIDI converter


### PR DESCRIPTION
I forgot to test the automatic Windows builds and 3.8 is apparently a tad outdated. Seems to work now after updating to 3.11.